### PR TITLE
fix db base image version

### DIFF
--- a/local/db/Dockerfile
+++ b/local/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7.32
 
 ENV MYSQL_USER=root
 ENV MYSQL_PASSWORD=


### PR DESCRIPTION
ベースイメージのアップデートにより、現状の設定のままではMySQLが起動しないため以前のバージョンに固定します