### PR TITLE
update portscan module

### DIFF
--- a/pkg/portscan/portscan_test.go
+++ b/pkg/portscan/portscan_test.go
@@ -1,6 +1,7 @@
 package portscan
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -88,6 +89,101 @@ func TestGetTags(t *testing.T) {
 	}
 }
 
+func TestGetDescription(t *testing.T) {
+	cases := []struct {
+		name       string
+		nmapResult *NmapResult
+		expect     string
+	}{
+		{
+			name: "Not Exist StatusDetail",
+			nmapResult: &NmapResult{
+				ResourceName: "hogeResource",
+				Target:       "example.com",
+				Protocol:     "tcp",
+				Status:       "closed",
+				Service:      "hoge-service",
+				Port:         8080,
+			},
+			expect: fmt.Sprintf("target: %v, protocol: %v, port: %v, status: %v, service: %v", "example.com", "tcp", "8080", "closed", "hoge-service"),
+		},
+		{
+			name: "Exist StatusDetail (status)",
+			nmapResult: &NmapResult{
+				ResourceName: "hogeResource",
+				Target:       "example.com",
+				Protocol:     "tcp",
+				Status:       "closed",
+				Service:      "hoge-service",
+				Port:         8080,
+				ScanDetail: map[string]interface{}{
+					"status": 200,
+				},
+			},
+			expect: fmt.Sprintf("target: %v, protocol: %v, port: %v, status: %v, service: %v, code: %v", "example.com", "tcp", "8080", "closed", "hoge-service", "200"),
+		},
+		{
+			name: "Exist StatusDetail (status,server)",
+			nmapResult: &NmapResult{
+				ResourceName: "hogeResource",
+				Target:       "example.com",
+				Protocol:     "tcp",
+				Status:       "closed",
+				Service:      "hoge-service",
+				Port:         8080,
+				ScanDetail: map[string]interface{}{
+					"status": 200,
+					"server": "hoge-server",
+				},
+			},
+			expect: fmt.Sprintf("target: %v, protocol: %v, port: %v, status: %v, service: %v, code: %v, server: %v", "example.com", "tcp", "8080", "closed", "hoge-service", "200", "hoge-server"),
+		},
+		{
+			name: "Exist StatusDetail (status,server,redirect)",
+			nmapResult: &NmapResult{
+				ResourceName: "hogeResource",
+				Target:       "example.com",
+				Protocol:     "tcp",
+				Status:       "closed",
+				Service:      "hoge-service",
+				Port:         8080,
+				ScanDetail: map[string]interface{}{
+					"status":   200,
+					"server":   "hoge-server",
+					"redirect": []string{"http://hoge1.com/fuga", "http://hoge2.com/fuga"},
+				},
+			},
+			expect: fmt.Sprintf("target: %v, protocol: %v, port: %v, status: %v, service: %v, code: %v, server: %v, redirect: %v", "example.com", "tcp", "8080", "closed", "hoge-service", "200", "hoge-server", "http://hoge1.com/fuga,http://hoge2.com/fuga"),
+		},
+		{
+			name: "Exist StatusDetail (status,server,redirect) Over 200 char",
+			nmapResult: &NmapResult{
+				ResourceName: "hogeResource",
+				Target:       "example.com",
+				Protocol:     "tcp",
+				Status:       "closed",
+				Service:      "hoge-service",
+				Port:         8080,
+				ScanDetail: map[string]interface{}{
+					"status":   200,
+					"server":   "hoge-server",
+					"redirect": []string{"http://hoge1.com/fuga", "http://hoge2.com/fuga", "http://hoge2.com/fuga/piyopiyopiyo"},
+				},
+			},
+			expect: fmt.Sprintf("target: %v, protocol: %v, port: %v, status: %v, service: %v, code: %v, server: %v, redirect: %v", "example.com", "tcp", "8080", "closed", "hoge-service", "200", "hoge-server", "http://hoge1.com/fuga,http://hoge2.com/fuga,http://hoge2.com/fuga/pi..."),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			description := c.nmapResult.GetDescription()
+			if c.expect != description {
+				fmt.Printf("%v\n", len(description))
+				t.Fatalf("Unexpected score: want=%v, got=%v", c.expect, description)
+			}
+		})
+	}
+}
+
 func TestGetScore(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -163,23 +259,49 @@ func TestGetScore(t *testing.T) {
 func TestGetScoreByScanDetail(t *testing.T) {
 	cases := []struct {
 		name        string
+		service     string
+		port        int
 		detail      map[string]interface{}
 		expectScore float32
 	}{
 		{
 			name:        "Score: 6.0 Status doesn't exist.",
+			service:     "http",
+			port:        80,
 			detail:      map[string]interface{}{},
 			expectScore: 6.0,
 		},
 		{
-			name: "Score: 1.0 Status 401/403",
+			name:    "Score: 1.0 HTTPS Status 401/403",
+			service: "https",
+			port:    8443,
 			detail: map[string]interface{}{
 				"status": "403 Forbidden",
 			},
 			expectScore: 1.0,
 		},
 		{
-			name: "Score: 6.0 Status without 401/403",
+			name:    "Score: 1.0 Port 443 HTTPS Status 401/403",
+			service: "http-alt",
+			port:    443,
+			detail: map[string]interface{}{
+				"status": "403 Forbidden",
+			},
+			expectScore: 1.0,
+		},
+		{
+			name:    "Score: 6.0 HTTP Status 401/403",
+			service: "http-alt",
+			port:    8080,
+			detail: map[string]interface{}{
+				"status": "403 Forbidden",
+			},
+			expectScore: 6.0,
+		},
+		{
+			name:    "Score: 6.0 Status without 401/403",
+			service: "http-alt",
+			port:    8080,
 			detail: map[string]interface{}{
 				"status": "200 OK",
 			},
@@ -188,7 +310,7 @@ func TestGetScoreByScanDetail(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			score := getScoreByScanDetail(c.detail)
+			score := getScoreByScanDetail(c.service, c.port, c.detail)
 			if c.expectScore != score {
 				t.Fatalf("Unexpected score: want=%v, got=%v", c.expectScore, score)
 			}


### PR DESCRIPTION
descriptionの表記を変更しました。
httpsでなく、401/403でない場合、スコアを0.1 -> 0.6に変更しました。
Nmapの結果に対するHTTPのチェックにて以下の変更を行いました。
- Header全てではなく、Serverのみ取得
- Redirectの追跡を追加