### PR TITLE
fix portscan module

### DIFF
--- a/pkg/portscan/analyze.go
+++ b/pkg/portscan/analyze.go
@@ -21,14 +21,18 @@ func (n *NmapResult) analyzeResult() error {
 		n.ScanDetail = data
 		return nil
 	}
-
-	switch n.Port {
-	default:
-		data, err := analyzeHTTP(n.Target, n.Port)
-		if err != nil {
-			return nil
+	switch n.Protocol {
+	case "tcp":
+		switch n.Port {
+		default:
+			data, err := analyzeHTTP(n.Target, n.Port)
+			if err != nil {
+				return nil
+			}
+			n.ScanDetail = data
 		}
-		n.ScanDetail = data
+	case "udp":
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
analyze HTTPは、UDPでは特に何かを検出しないため速度向上を目的としてTCPの場合のみ実行するようにします