### PR TITLE
fix: public ci flow

### DIFF
--- a/codebuild/multi-arch/buildspec-manifest.yml
+++ b/codebuild/multi-arch/buildspec-manifest.yml
@@ -2,10 +2,10 @@ version: 0.2
 
 env:
   variables:
-    IMAGE_PREFIX: "risken-middleware"
+    IMAGE_PREFIX: 'risken-middleware'
   parameter-store:
-    GITHUB_USER: "/build/GITHUB_USER"
-    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+    GITHUB_USER: '/build/GITHUB_USER'
+    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
 
 phases:
   install:
@@ -30,6 +30,7 @@ phases:
     commands:
       - echo Create manifests...
       - cd ${MIDDLEWARE} && make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} MANIFEST_TAG=${MANIFEST_TAG}
+      - cd ${MIDDLEWARE} && make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - cd ${MIDDLEWARE} && make create-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} MANIFEST_TAG=latest
 
   post_build:
@@ -37,5 +38,5 @@ phases:
       - echo Build completed on `date`
       - echo Pushing the Docker manifest...
       - cd ${MIDDLEWARE} && make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${MANIFEST_TAG}
+      - cd ${MIDDLEWARE} && make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - cd ${MIDDLEWARE} && make push-manifest -j IMAGE_REGISTRY=${REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=latest
-

--- a/codebuild/release/buildspec-batch.yml
+++ b/codebuild/release/buildspec-batch.yml
@@ -1,0 +1,32 @@
+batch:
+  build-graph:
+    - identifier: build_amd64
+      buildspec: codebuild/release/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          OS: linux
+          ARCH: amd64
+    - identifier: build_arm64
+      buildspec: codebuild/release/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          OS: linux
+          ARCH: arm64
+    - identifier: build_manifest
+      buildspec: codebuild/release/buildspec-manifest.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+      depend-on:
+        - build_amd64
+        - build_arm64

--- a/codebuild/release/buildspec-image.yml
+++ b/codebuild/release/buildspec-image.yml
@@ -1,0 +1,53 @@
+version: 0.2
+
+env:
+  variables:
+    PRIVATE_IMAGE_PREFIX: 'risken-middleware'
+    PUBLIC_REGISTRY: 'public.ecr.aws/risken'
+    PUBLIC_IMAGE_PREFIX: 'middleware'
+  parameter-store:
+    GITHUB_USER: '/build/GITHUB_USER'
+    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
+    DOCKER_USER: '/build/DOCKER_USER'
+    DOCKER_TOKEN: '/build/DOCKER_TOKEN'
+
+phases:
+  install:
+    commands:
+      - echo "machine github.com" > ~/.netrc
+      - echo "login ${GITHUB_USER}" >> ~/.netrc
+      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - MIDDLEWARE=${CODEBUILD_SRC_DIR}/middleware
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+      - PRIVATE_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+      - TAG=${CODEBUILD_WEBHOOK_TRIGGER#tag/}
+      - IMAGE_TAG=${TAG}_${OS}_${ARCH}
+
+      - echo Logging in to Amazon ECR (private)...
+      - aws --version
+      - aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${PRIVATE_REGISTRY}
+  build:
+    commands:
+      - echo Build middleware started on `date`
+      - echo pull images...
+      - cd ${MIDDLEWARE} && make pull-image -j IMAGE_PREFIX=${PRIVATE_IMAGE_PREFIX} IMAGE_REGISTRY=${PRIVATE_REGISTRY} IMAGE_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+
+      - echo tag images...
+      - cd ${MIDDLEWARE} && make tag-image -j IMAGE_PREFIX=${PRIVATE_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - cd ${MIDDLEWARE} && make tag-image -j IMAGE_PREFIX=${PRIVATE_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=${TAG}
+      - cd ${MIDDLEWARE} && make tag-image -j IMAGE_PREFIX=${PRIVATE_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=latest
+
+  post_build:
+    commands:
+      - echo Logging in to Amazon ECR (public)...
+      - aws --version
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
+
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+      - cd ${MIDDLEWARE} && make push-image -j IMAGE_PREFIX=${PUBLIC_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - cd ${MIDDLEWARE} && make push-image -j IMAGE_PREFIX=${PUBLIC_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=${TAG}
+      - cd ${MIDDLEWARE} && make push-image -j IMAGE_PREFIX=${PUBLIC_IMAGE_PREFIX} IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_TAG=latest

--- a/codebuild/release/buildspec-manifest.yml
+++ b/codebuild/release/buildspec-manifest.yml
@@ -1,0 +1,40 @@
+version: 0.2
+
+env:
+  variables:
+    PUBLIC_REGISTRY: 'public.ecr.aws/risken'
+    IMAGE_PREFIX: 'middleware'
+
+  parameter-store:
+    GITHUB_USER: '/build/GITHUB_USER'
+    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
+
+phases:
+  install:
+    commands:
+      - echo "machine github.com" > ~/.netrc
+      - echo "login ${GITHUB_USER}" >> ~/.netrc
+      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=${CODEBUILD_WEBHOOK_TRIGGER#tag/}
+
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
+  build:
+    commands:
+      - echo Create manifests...
+      - make create-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - make create-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=${TAG}
+      - make create-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG_BASE=${TAG} MANIFEST_TAG=latest
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker manifest...
+      - make push-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - make push-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=${TAG}
+      - make push-manifest -j IMAGE_REGISTRY=${PUBLIC_REGISTRY} IMAGE_PREFIX=${IMAGE_PREFIX} MANIFEST_TAG=latest

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -2,6 +2,8 @@ TARGETS = db queue
 BUILD_TARGETS = $(TARGETS:=.build)
 BUILD_CI_TARGETS = $(TARGETS:=.build-ci)
 IMAGE_PUSH_TARGETS = $(TARGETS:=.push-image)
+IMAGE_PULL_TARGETS = $(TARGETS:=.pull-image)
+IMAGE_TAG_TARGETS = $(TARGETS:=.tag-image)
 MANIFEST_CREATE_TARGETS = $(TARGETS:=.create-manifest)
 MANIFEST_PUSH_TARGETS = $(TARGETS:=.push-manifest)
 TEST_TARGETS = $(TARGETS:=.go-test)
@@ -30,6 +32,16 @@ PHONY: push-image $(IMAGE_PUSH_TARGETS)
 push-image: $(IMAGE_PUSH_TARGETS)
 %.push-image:
 	docker push $(IMAGE_REGISTRY)/$(IMAGE_PREFIX)/$(*):$(IMAGE_TAG)
+
+PHONY: pull-image $(IMAGE_PULL_TARGETS)
+pull-image: $(IMAGE_PULL_TARGETS)
+%.pull-image:
+	docker pull $(IMAGE_REGISTRY)/$(IMAGE_PREFIX)/$(*):$(IMAGE_TAG)
+
+PHONY: tag-image $(IMAGE_TAG_TARGETS)
+tag-image: $(IMAGE_TAG_TARGETS)
+%.tag-image:
+	docker tag $(IMAGE_PREFIX)/$(*):$(IMAGE_TAG) $(IMAGE_REGISTRY)/$(IMAGE_PREFIX)/$(*):$(IMAGE_TAG)
 
 PHONY: create-manifest $(MANIFEST_CREATE_TARGETS)
 create-manifest: $(MANIFEST_CREATE_TARGETS)


### PR DESCRIPTION
middlewareのリリースフロー修正します。
- プライベートリポジトリにpush する際にgitのハッシュ値のタグをつけておく
- 上記のタグをキーにプライベートリポジトリからイメージをpull
- パブリックリポジトリにイメージpush