### PR TITLE
fix: finalizer use default template

### DIFF
--- a/pkg/sqs/finalizer.go
+++ b/pkg/sqs/finalizer.go
@@ -12,35 +12,60 @@ import (
 )
 
 type Finalizer struct {
-	findingClient finding.FindingServiceClient
+	datasource     string
+	recommendation *DataSourceRecommnend
+	findingClient  finding.FindingServiceClient
 }
 
-func NewFinalizer(findingSvcAddr string) *Finalizer {
+// NewFinalizer returns a Finalizer instance and generates recommendation contents for scan failure from the datasource and settingURL parameter.
+// If set overrideRecommendation, the above contents will be overridden.
+func NewFinalizer(datasource, settingURL, findingSvcAddr string, overrideRecommendation *DataSourceRecommnend) *Finalizer {
 	return &Finalizer{
-		findingClient: newFindingClient(findingSvcAddr),
+		datasource:     datasource,
+		recommendation: generateRecommendation(datasource, settingURL, overrideRecommendation),
+		findingClient:  newFindingClient(findingSvcAddr),
 	}
 }
 
-// DataSourceRecommnend needs to implement scan failure recommendations contents per datasource
-type DataSourceRecommnend interface {
-	// DataSource returns the DataSource identifier string.(e.g. 'aws:portscan')
-	DataSource() string
-	// ScanFailureRisk returns risk information in case of scan failure.
-	ScanFailureRisk() string
-	// ScanFailureRecommend returns information on what action is required in case of scan failure.
-	ScanFailureRecommend() string
+const (
+	scanFailureRiskTemplate      = "Failed to scan %s, So you are not gathering the latest security threat information."
+	scanFailureRecommendTemplate = `Please review the following items and rescan,
+	- Ensure the error message of the DataSource.
+	- Ensure the access rights you set for the DataSource and the reachability of the network.
+	- Refer to the documentation to make sure you have not omitted any of the steps you have set up.
+	- %s
+	- If this does not resolve the problem, or if you suspect that the problem is server-side, please contact the system administrators.`
+)
+
+type DataSourceRecommnend struct {
+	// ScanFailureRisk is risk information in case of scan failure.
+	ScanFailureRisk string `json:"scan_failure_risk,omitempty"`
+	// ScanFailureRecommendation is information on what action is required in case of scan failure.
+	ScanFailureRecommendation string `json:"scan_failure_recommendation,omitempty"`
+}
+
+func generateRecommendation(datasource, settingURL string, override *DataSourceRecommnend) *DataSourceRecommnend {
+	recommend := DataSourceRecommnend{
+		ScanFailureRisk:           fmt.Sprintf(scanFailureRiskTemplate, datasource),
+		ScanFailureRecommendation: fmt.Sprintf(scanFailureRecommendTemplate, settingURL),
+	}
+	if override != nil {
+		recommend.ScanFailureRisk = override.ScanFailureRisk
+		recommend.ScanFailureRecommendation = override.ScanFailureRecommendation
+	}
+	return &recommend
 }
 
 // FinalizeHandler returns a Handler that wraps the termination process
-func (f *Finalizer) FinalizeHandler(datasource DataSourceRecommnend, next Handler) Handler {
+func (f *Finalizer) FinalizeHandler(next Handler) Handler {
 	return HandlerFunc(func(ctx context.Context, sqsMsg *sqs.Message) error {
 		err := next.HandleMessage(ctx, sqsMsg)
 		projectID, parseErr := parseProjectFromMessage(aws.StringValue(sqsMsg.Body))
 		if parseErr != nil {
 			appLogger.Errorf("Invalid message(failed to get project_id): sqsMsg=%+v, err=%+v", sqsMsg, parseErr)
-			return f.Final(ctx, nil, datasource, err)
+			return f.Final(ctx, nil, err)
 		}
-		return f.Final(ctx, &projectID, datasource, err)
+		return f.Final(ctx, &projectID, err)
 	})
 }
 
@@ -56,13 +81,8 @@ func parseProjectFromMessage(msg string) (uint32, error) {
 	return message.ProjectID, nil
 }
 
-type recommend struct {
-	Risk           string `json:"risk,omitempty"`
-	Recommendation string `json:"recommendation,omitempty"`
-}
-
 // Final summarizes the termination scan process
-func (f *Finalizer) Final(ctx context.Context, projectID *uint32, datasource DataSourceRecommnend, err error) error {
+func (f *Finalizer) Final(ctx context.Context, projectID *uint32, err error) error {
 	if projectID == nil {
 		// Unknown project
 		appLogger.Notifyf(logging.ErrorLevel, "Unknown project, err: %+v", err)
@@ -72,12 +92,12 @@ func (f *Finalizer) Final(ctx context.Context, projectID *uint32, datasource Dat
 		// Scan failed
 		if putErr := f.putScanFinding(ctx, projectID, &ScanFinding{
 			ProjectID:    *projectID,
-			DataSource:   datasource.DataSource(),
+			DataSource:   f.datasource,
 			Status:       "Error",
 			ErrorMessage: err.Error(),
-			Recommend: recommend{
-				Risk:           datasource.ScanFailureRisk(),
-				Recommendation: datasource.ScanFailureRecommend(),
+			Recommendation: &DataSourceRecommnend{
+				ScanFailureRisk:           f.recommendation.ScanFailureRisk,
+				ScanFailureRecommendation: f.recommendation.ScanFailureRecommendation,
 			},
 		}); putErr != nil {
 			appLogger.Notifyf(logging.ErrorLevel, "Failed to putScanFinding (scan failed), project_id: %d, err: %+v", *projectID, putErr)
@@ -89,11 +109,11 @@ func (f *Finalizer) Final(ctx context.Context, projectID *uint32, datasource Dat
 	// Scan succeeded
 	if putErr := f.putScanFinding(ctx, projectID, &ScanFinding{
 		ProjectID:  *projectID,
-		DataSource: datasource.DataSource(),
+		DataSource: f.datasource,
 		Status:     "OK",
-		Recommend: recommend{
-			Risk:           datasource.ScanFailureRisk(),
-			Recommendation: datasource.ScanFailureRecommend(),
+		Recommendation: &DataSourceRecommnend{
+			ScanFailureRisk:           f.recommendation.ScanFailureRisk,
+			ScanFailureRecommendation: f.recommendation.ScanFailureRecommendation,
 		},
 	}); putErr != nil {
 		appLogger.Notifyf(logging.ErrorLevel, "Failed to putScanFinding (scan succeeded), project_id: %d, err: %+v", *projectID, putErr)
@@ -103,11 +123,11 @@ func (f *Finalizer) Final(ctx context.Context, projectID *uint32, datasource Dat
 }
 
 type ScanFinding struct {
-	ProjectID    uint32    `json:"project_id,omitempty"`
-	DataSource   string    `json:"data_source,omitempty"`
-	Status       string    `json:"status,omitempty"`
-	ErrorMessage string    `json:"error_message,omitempty"`
-	Recommend    recommend `json:"recommend,omitempty"`
+	ProjectID      uint32                `json:"project_id,omitempty"`
+	DataSource     string                `json:"data_source,omitempty"`
+	Status         string                `json:"status,omitempty"`
+	ErrorMessage   string                `json:"error_message,omitempty"`
+	Recommendation *DataSourceRecommnend `json:"recommendation,omitempty"`
 }
 
 func (f *Finalizer) putScanFinding(ctx context.Context, projectID *uint32, sf *ScanFinding) error {
@@ -146,8 +166,8 @@ func (f *Finalizer) putScanFinding(ctx context.Context, projectID *uint32, sf *S
 		FindingId:      resp.Finding.FindingId,
 		DataSource:     "RISKEN",
 		Type:           fmt.Sprintf("ScanError/%s", sf.DataSource),
-		Risk:           sf.Recommend.Risk,
-		Recommendation: sf.Recommend.Recommendation,
+		Risk:           sf.Recommendation.ScanFailureRisk,
+		Recommendation: sf.Recommendation.ScanFailureRecommendation,
 	}); err != nil {
 		return fmt.Errorf("Failed to put scan finding recommned, finding_id=%d, error=%+v", resp.Finding.FindingId, err)
 	}

--- a/pkg/sqs/finalizer_test.go
+++ b/pkg/sqs/finalizer_test.go
@@ -3,6 +3,8 @@ package sqs
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/ca-risken/core/proto/finding"
@@ -11,14 +13,87 @@ import (
 )
 
 var (
-	sampleProjectID uint32 = 1
+	sampleProjectID  uint32 = 1
+	sampleDataSource string = "namespace:datasource"
+	sampleSettingURL string = "https://docs.security-hub.jp/"
 )
+
+func TestGenerateRecommendation(t *testing.T) {
+	type args struct {
+		datasource string
+		settingURL string
+		override   *DataSourceRecommnend
+	}
+	cases := []struct {
+		name  string
+		input args
+		want  *DataSourceRecommnend
+	}{
+		{
+			name: "OK",
+			input: args{
+				datasource: sampleDataSource,
+				settingURL: sampleSettingURL,
+				override:   nil,
+			},
+			want: &DataSourceRecommnend{
+				ScanFailureRisk: "Failed to scan namespace:datasource, So you are not gathering the latest security threat information.",
+				ScanFailureRecommendation: `Please review the following items and rescan,
+	- Ensure the error message of the DataSource.
+	- Ensure the access rights you set for the DataSource and the reachability of the network.
+	- Refer to the documentation to make sure you have not omitted any of the steps you have set up.
+	- https://docs.security-hub.jp/
+	- If this does not resolve the problem, or if you suspect that the problem is server-side, please contact the system administrators.`,
+			},
+		},
+		{
+			name: "Ovverride",
+			input: args{
+				datasource: sampleDataSource,
+				settingURL: sampleSettingURL,
+				override: &DataSourceRecommnend{
+					ScanFailureRisk:           "overriden risk",
+					ScanFailureRecommendation: "overriden recommendation",
+				},
+			},
+			want: &DataSourceRecommnend{
+				ScanFailureRisk:           "overriden risk",
+				ScanFailureRecommendation: "overriden recommendation",
+			},
+		},
+		{
+			name: "Blank",
+			input: args{
+				datasource: "",
+				settingURL: "",
+				override:   nil,
+			},
+			want: &DataSourceRecommnend{
+				ScanFailureRisk: "Failed to scan , So you are not gathering the latest security threat information.",
+				ScanFailureRecommendation: `Please review the following items and rescan,
+	- Ensure the error message of the DataSource.
+	- Ensure the access rights you set for the DataSource and the reachability of the network.
+	- Refer to the documentation to make sure you have not omitted any of the steps you have set up.
+	- 
+	- If this does not resolve the problem, or if you suspect that the problem is server-side, please contact the system administrators.`,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := generateRecommendation(c.input.datasource, c.input.settingURL, c.input.override)
+			if !reflect.DeepEqual(c.want, got) {
+				t.Fatalf("Unexpected data match: want=%+v, got=%+v", c.want, got)
+			}
+		})
+	}
+
+}
 
 func TestFinal(t *testing.T) {
 	type args struct {
-		ProjectID  *uint32
-		DataSource DataSourceRecommnend
-		Err        error
+		ProjectID *uint32
+		Err       error
 	}
 	mockClient := mocks.FindingServiceClient{}
 	type mockResponse struct {
@@ -37,9 +112,8 @@ func TestFinal(t *testing.T) {
 		{
 			name: "OK(no scan error)",
 			input: args{
-				ProjectID:  &sampleProjectID,
-				DataSource: &sampleDataSourceRecommend{},
-				Err:        nil,
+				ProjectID: &sampleProjectID,
+				Err:       nil,
 			},
 			mockResp: mockResponse{
 				PutFindingResp:   &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1}},
@@ -52,9 +126,8 @@ func TestFinal(t *testing.T) {
 		{
 			name: "OK(exists scan error)",
 			input: args{
-				ProjectID:  &sampleProjectID,
-				DataSource: &sampleDataSourceRecommend{},
-				Err:        errors.New("Failed to scan"),
+				ProjectID: &sampleProjectID,
+				Err:       errors.New("Failed to scan"),
 			},
 			mockResp: mockResponse{
 				PutFindingResp:   &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1}},
@@ -67,9 +140,8 @@ func TestFinal(t *testing.T) {
 		{
 			name: "ProjectID is nil(error)",
 			input: args{
-				ProjectID:  nil,
-				DataSource: &sampleDataSourceRecommend{},
-				Err:        errors.New("Failed to scan"),
+				ProjectID: nil,
+				Err:       errors.New("Failed to scan"),
 			},
 			mockResp: mockResponse{},
 			wantErr:  true,
@@ -77,9 +149,8 @@ func TestFinal(t *testing.T) {
 		{
 			name: "ProjectID is nil(no error)",
 			input: args{
-				ProjectID:  nil,
-				DataSource: &sampleDataSourceRecommend{},
-				Err:        nil,
+				ProjectID: nil,
+				Err:       nil,
 			},
 			mockResp: mockResponse{},
 			wantErr:  false,
@@ -87,9 +158,8 @@ func TestFinal(t *testing.T) {
 		{
 			name: "Failed to PutFinding API",
 			input: args{
-				ProjectID:  &sampleProjectID,
-				DataSource: &sampleDataSourceRecommend{},
-				Err:        nil,
+				ProjectID: &sampleProjectID,
+				Err:       nil,
 			},
 			mockResp: mockResponse{
 				PutFindingResp:   nil,
@@ -102,9 +172,8 @@ func TestFinal(t *testing.T) {
 		{
 			name: "Failed to PutRecommend API",
 			input: args{
-				ProjectID:  &sampleProjectID,
-				DataSource: &sampleDataSourceRecommend{},
-				Err:        nil,
+				ProjectID: &sampleProjectID,
+				Err:       nil,
 			},
 			mockResp: mockResponse{
 				PutFindingResp:   &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1}},
@@ -118,7 +187,14 @@ func TestFinal(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			// setting mock client
-			f := Finalizer{findingClient: &mockClient}
+			f := Finalizer{
+				datasource: sampleDataSource,
+				recommendation: &DataSourceRecommnend{
+					ScanFailureRisk:           fmt.Sprintf(scanFailureRiskTemplate, sampleDataSource),
+					ScanFailureRecommendation: fmt.Sprintf(scanFailureRecommendTemplate, sampleSettingURL),
+				},
+				findingClient: &mockClient,
+			}
 			if c.mockResp.PutFindingResp != nil || c.mockResp.PutFindingErr != nil {
 				mockClient.On("PutFinding", mock.Anything, mock.Anything).Return(
 					c.mockResp.PutFindingResp, c.mockResp.PutFindingErr).Once()
@@ -130,7 +206,7 @@ func TestFinal(t *testing.T) {
 
 			// exec function
 			ctx := context.Background()
-			err := f.Final(ctx, c.input.ProjectID, c.input.DataSource, c.input.Err)
+			err := f.Final(ctx, c.input.ProjectID, c.input.Err)
 			if err == nil && c.wantErr {
 				t.Fatalf("Unexpected no error: wantErr=%t", c.wantErr)
 			}
@@ -139,18 +215,4 @@ func TestFinal(t *testing.T) {
 			}
 		})
 	}
-}
-
-type sampleDataSourceRecommend struct{}
-
-func (s *sampleDataSourceRecommend) DataSource() string {
-	return "namespace:datasource"
-}
-
-func (s *sampleDataSourceRecommend) ScanFailureRisk() string {
-	return "Failed to scan, So you are not gathering the latest security threat information."
-}
-
-func (s *sampleDataSourceRecommend) ScanFailureRecommend() string {
-	return "Please review the following items and rescan, ...."
 }

--- a/pkg/sqs/grpc.go
+++ b/pkg/sqs/grpc.go
@@ -19,7 +19,6 @@ func newFindingClient(svcAddr string) finding.FindingServiceClient {
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {
-	// gRPCクライアントの呼び出し回数が非常に多くトレーシング情報の送信がエラーになるため、トレースは無効にしておく
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/pkg/sqs/grpc.go
+++ b/pkg/sqs/grpc.go
@@ -2,6 +2,7 @@ package sqs
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/finding"
@@ -9,13 +10,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
+func newFindingClient(svcAddr string) (finding.FindingServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf("Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("Faild to get GRPC connection: err=%+v", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
メンテナンス性の観点でスキャン失敗時のレコメンドテンプレートを使って生成するように修正します
- 多くのデータソースがテンプレートのコンテンツを利用する想定（データソースごとに修正するコストをへらす目的）
- 一部のデータソースはレコメンドの内容が変わるため、上書きできるようなパラメータを用意