### PR TITLE
Fix lint error

### DIFF
--- a/pkg/logging/go.mod
+++ b/pkg/logging/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 )
 
-require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/pkg/logging/go.sum
+++ b/pkg/logging/go.sum
@@ -10,3 +10,5 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
ローカル環境で`make lint`を実行したところ、loggingパッケージでtypecheckのエラーが検出された。
loggingパッケージをビルドするとコンパイルエラーが確認できた。
以下の関連リンクを参照すると、同様の問題に対して`golang.org/x/sys`の更新が推奨されていたためその対応を実施した。
ローカル環境でエラーにならないことは確認済みです。

* 関連リンク
https://github.com/golang/go/issues/51706
https://stackoverflow.com/questions/71507321/go-1-18-build-error-on-mac-unix-syscall-darwin-1-13-go253-golinkname-mus

* typecheckのエラー
```
logger.go:76:4: a.Logf undefined (type *AppLogger has no field or method Logf) (typecheck)
	a.Logf(logrus.DebugLevel, format, args...)
	  ^
logger.go:80:4: a.Logf undefined (type *AppLogger has no field or method Logf) (typecheck)
	a.Logf(logrus.InfoLevel, format, args...)
	  ^
logger.go:84:4: a.Logf undefined (type *AppLogger has no field or method Logf) (typecheck)
	a.Logf(logrus.WarnLevel, format, args...)
	  ^
logger.go:97:4: a.Exit undefined (type *AppLogger has no field or method Exit) (typecheck)
	a.Exit(1)
	  ^
logger.go:105:4: a.Log undefined (type *AppLogger has no field or method Log) (typecheck)
	a.Log(logrus.DebugLevel, args...)
	  ^
logger.go:109:4: a.Log undefined (type *AppLogger has no field or method Log) (typecheck)
	a.Log(logrus.InfoLevel, args...)
	  ^
logger.go:113:4: a.Log undefined (type *AppLogger has no field or method Log) (typecheck)
	a.Log(logrus.WarnLevel, args...)
	  ^
logger.go:126:4: a.Exit undefined (type *AppLogger has no field or method Exit) (typecheck)
	a.Exit(1)
	  ^
logger.go:155:4: a.SetLevel undefined (type *AppLogger has no field or method SetLevel) (typecheck)
	a.SetLevel(parseLogrusLevel(level))
	  ^
logger.go:159:4: a.SetOutput undefined (type *AppLogger has no field or method SetOutput) (typecheck)
	a.SetOutput(w)
	  ^
logger.go:175:4: a.WithFields undefined (type *AppLogger has no field or method WithFields) (typecheck)
	a.WithFields(logrus.Fields{
	  ^
logger.go:181:4: a.WithFields undefined (type *AppLogger has no field or method WithFields) (typecheck)
	a.WithFields(logrus.Fields{
	  ^
logger.go:191:4: a.WithFields undefined (type *AppLogger has no field or method WithFields) (typecheck)
	a.WithFields(f).Log(parseLogrusLevel(level), args...)
	  ^
make: *** [logging.lint] Error 1
```

* loggingパッケージのコンパイルエラー
```
$ go build
# golang.org/x/sys/unix
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.1_13.go:40:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
XXX/go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:121:3: too many errors
```