### PR TITLE
Append tracing tag when worker returns error

### DIFF
--- a/pkg/sqs/handler.go
+++ b/pkg/sqs/handler.go
@@ -77,9 +77,8 @@ func TracingHandler(serviceName string, h Handler) Handler {
 	return HandlerFunc(func(ctx context.Context, msg *awssqs.Message) error {
 		span, tctx := ddtracer.StartSpanFromContext(ctx, serviceName)
 		// TODO inherit trace from message
-		defer span.Finish()
-
 		err := h.HandleMessage(tctx, msg)
+		span.Finish(ddtracer.WithError(err))
 		return err
 	})
 }


### PR DESCRIPTION
Workerがエラーを返した時にトレーシング情報のエラーを表すタグを設定するように変更