### PR TITLE
fix portscan score

### DIFF
--- a/pkg/portscan/finding.go
+++ b/pkg/portscan/finding.go
@@ -184,21 +184,21 @@ func GetAdditionalCheckResult(key string) (AdditionalCheckResult, bool) {
 }
 
 var httpCheckResult = map[string]AdditionalCheckResult{
-	"isHTTPOpenProxy": AdditionalCheckResult{Score: 0.8, Tag: []string{"http"}, Type: "isHTTPOpenProxy",
+	"isHTTPOpenProxy": AdditionalCheckResult{Score: 8.0, Tag: []string{"http"}, Type: "isHTTPOpenProxy",
 		Description: "{TARGET} is Potentially OPEN proxy. port: {PORT}",
 		Risk: `HTTP Open Proxies is Enabled.
 	- Malicious client can use an open proxy to launch an attack that originates from the proxy server's IP.`,
 		Recommendation: `Disable open proxy.
 	- Restrict target TCP and UDP port to trusted IP addresses.
 	- Allow specific users to use the proxy by authenticating them.`},
-	"isSSHEnabledPasswordAuth": AdditionalCheckResult{Score: 0.8, Tag: []string{"ssh"}, Type: "isSSHEnabledPasswordAuth",
+	"isSSHEnabledPasswordAuth": AdditionalCheckResult{Score: 8.0, Tag: []string{"ssh"}, Type: "isSSHEnabledPasswordAuth",
 		Description: "{TARGET} is supported password authentication. port: {PORT}",
 		Risk: `SSH Password Authentication is Enabled.
 	- If weak passwords are used, ssh servers are vulnerable to brute force attacks.`,
 		Recommendation: `Stop the open proxy.
 	- Restrict target port to trusted IP addresses.
 	- disable password authentication.`},
-	"isSMTPOpenRelay": AdditionalCheckResult{Score: 0.8, Tag: []string{"smtp"}, Type: "isSMTPOpenRelay",
+	"isSMTPOpenRelay": AdditionalCheckResult{Score: 8.0, Tag: []string{"smtp"}, Type: "isSMTPOpenRelay",
 		Description: "{TARGET} is an open relay. port: {PORT}",
 		Risk: `SMTP Open Relay is Enabled.
 	- Spammers can exploit open SMTP relays to send large amounts of email.

--- a/pkg/portscan/portscan_test.go
+++ b/pkg/portscan/portscan_test.go
@@ -381,7 +381,7 @@ func TestGetAdditionalCheck(t *testing.T) {
 		{
 			name: "AdditionalCheckResult is found.",
 			key:  "isHTTPOpenProxy",
-			expect: AdditionalCheckResult{Score: 0.8, Tag: []string{"http"}, Type: "isHTTPOpenProxy",
+			expect: AdditionalCheckResult{Score: 8.0, Tag: []string{"http"}, Type: "isHTTPOpenProxy",
 				Description: "{TARGET} is Potentially OPEN proxy. port: {PORT}",
 				Risk: `HTTP Open Proxies is Enabled.
 	- Malicious client can use an open proxy to launch an attack that originates from the proxy server's IP.`,


### PR DESCRIPTION
portscan実行時のオープンポートに対する追加チェックのスコアを修正します。
originalMaxScore:10に対して、8を割り当てることで0.8のスコアになるように修正しています。