### PR TITLE
add code table

### DIFF
--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -489,6 +489,46 @@ CREATE TABLE code_enterprise_org (
   PRIMARY KEY(gitleaks_id, login)
 ) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
+CREATE TABLE code_github_setting (
+  code_github_setting_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  project_id INT UNSIGNED NOT NULL,
+  name VARCHAR(64) NULL,
+  github_user VARCHAR(64) NULL,
+  personal_access_token VARCHAR(255) NULL,
+  type ENUM('UNKNOWN_TYPE', 'ENTERPRISE' ,'ORGANIZATION', 'USER') NOT NULL DEFAULT 'UNKNOWN_TYPE',
+  base_url VARCHAR(128) NULL,
+  target_resource VARCHAR(128) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(code_github_setting_id),
+  UNIQUE KEY uidx_code_github_setting (name, project_id)
+) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin AUTO_INCREMENT = 1001;
+
+CREATE TABLE code_gitleaks_setting (
+  code_github_setting_id INT UNSIGNED NOT NULL,
+  project_id INT UNSIGNED NOT NULL,
+  code_data_source_id INT UNSIGNED NOT NULL,
+  repository_pattern VARCHAR(128) NULL,
+  scan_public ENUM('false', 'true') NOT NULL DEFAULT 'true',
+  scan_internal ENUM('false', 'true') NOT NULL DEFAULT 'true',
+  scan_private ENUM('false', 'true') NOT NULL DEFAULT 'false',
+  status ENUM('UNKNOWN', 'OK' ,'CONFIGURED', 'IN_PROGRESS', 'ERROR') NOT NULL DEFAULT 'UNKNOWN',
+  status_detail VARCHAR(255) NULL,
+  scan_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(code_github_setting_id)
+) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin AUTO_INCREMENT = 1001;
+
+CREATE TABLE code_github_enterprise_org (
+  code_github_setting_id INT UNSIGNED NOT NULL,
+  organization VARCHAR(128) NOT NULL,
+  project_id INT UNSIGNED NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(code_github_setting_id, organization)
+) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
 -- GOOGLE ------------------------------------------------
 CREATE TABLE google_data_source (
   google_data_source_id INT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/middleware/db/14_test_data_code.sql
+++ b/middleware/db/14_test_data_code.sql
@@ -6,4 +6,10 @@ use mimosa;
 INSERT INTO code_gitleaks(gitleaks_id, code_data_source_id, name, project_id, type, target_resource, repository_pattern, github_user, personal_access_token, gitleaks_config, status, status_detail, scan_at) VALUES
   (1001, 1001, "gitleaksk-name", 1001, 'USER', 'gitleakstest', 'gronit', '', '', '', 'CONFIGURED', '', null);
 
+INSERT INTO code_github_setting(code_github_setting_id, project_id, name, github_user, personal_access_token, type, base_url, target_resource) VALUES
+  (1001, 1001, 'code-github-setting-name', 'github-user', 'github-personal-access-token', 'USER', '', 'username');
+
+INSERT INTO code_gitleaks_setting(code_github_setting_id, project_id, code_data_source_id, repository_pattern, scan_public, scan_internal, scan_private, status, status_detail, scan_at) VALUES
+  (1001, 1001, 1001, '', 'true', 'true', 'true', 'CONFIGURED', '', null);
+
 commit;


### PR DESCRIPTION
code_gitleaksテーブルの情報を分離するために以下の修正を行います
- code_github_setting の追加
- code_gitleaks_setting の追加
- code_github_enterprise_org の追加

code_gitleaks,code_enterprise_orgテーブルは新テーブルへの移行作業が完了後削除します