### PR TITLE
fix: idx_project_id

### DIFF
--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -122,7 +122,7 @@ CREATE TABLE finding_tag (
   INDEX idx_finding_tag(tag)
 ) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin AUTO_INCREMENT = 1001;
 
-CREATE INDEX idx_project_id ON finding_tag (project_id);
+CREATE INDEX idx_project_id ON finding_tag (project_id, tag);
 
 CREATE TABLE resource (
   resource_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
finding_tagテーブルのクエリでスロークエリが発生していたのでIndex見直します。

以下のようなSQLがアプリで発行されるが、実行計画を確認したところ `Using temporary; Using filesort` が発生していました。
finding_tagテーブルのデータ量が多いこともあり、このソート処理がパフォーマンス影響していると考えます。
```sql
select
  tag
from
  finding_tag
where
  project_id = xxx
  and updated_at between '1970-01-01 09:00:00' and '2022-12-31 23:59:59'
group by project_id, tag
order by tag asc limit 0, 200;
```

本PRのIndexに修正することで、実行計画上 `Using temporary; Using filesort`が消えたことを確認しました。（タグ＝10万レコードの環境で検証したところ、クエリの速度も大幅に向上しました。（体感））