### PR TITLE
Improve error handling in portscan

### DIFF
--- a/pkg/portscan/analyze.go
+++ b/pkg/portscan/analyze.go
@@ -9,14 +9,14 @@ func (n *NmapResult) analyzeResult() error {
 	case "ssh":
 		data, err := analyzeSSH(n.Target, n.Port)
 		if err != nil {
-			return nil
+			return err
 		}
 		n.ScanDetail = data
 		return nil
 	case "smtp", "smtps", "submission":
 		data, err := analyzeSMTP(n.Target, n.Port)
 		if err != nil {
-			return nil
+			return err
 		}
 		n.ScanDetail = data
 		return nil
@@ -27,7 +27,7 @@ func (n *NmapResult) analyzeResult() error {
 		default:
 			data, err := analyzeHTTP(n.Target, n.Port)
 			if err != nil {
-				return nil
+				return err
 			}
 			n.ScanDetail = data
 		}

--- a/pkg/portscan/analyze_ssh.go
+++ b/pkg/portscan/analyze_ssh.go
@@ -9,14 +9,17 @@ import (
 )
 
 func analyzeSSH(target string, port int) (map[string]interface{}, error) {
-
+	open, err := checkSSHPasswordAuth(target, port)
+	if err != nil {
+		return nil, err
+	}
 	ret := map[string]interface{}{
-		"isSSHEnabledPasswordAuth": checkSSHPasswordAuth(target, port),
+		"isSSHEnabledPasswordAuth": open,
 	}
 	return ret, nil
 }
 
-func checkSSHPasswordAuth(target string, port int) bool {
+func checkSSHPasswordAuth(target string, port int) (bool, error) {
 	scanner, err := nmap.NewScanner(
 		nmap.WithTargets(target),
 		nmap.WithPorts(strconv.Itoa(port)),
@@ -27,21 +30,21 @@ func checkSSHPasswordAuth(target string, port int) bool {
 		nmap.WithTimingTemplate(nmap.TimingAggressive),
 	)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("failed to create scanner for SSH, err=%w", err)
 	}
 	result, warn, err := scanner.Run()
 	if err != nil {
 		fmt.Printf("Nmap warning: %v", warn)
-		return false
+		return false, fmt.Errorf("failed to run scanner for SSH, err=%w", err)
 	}
 	for _, host := range result.Hosts {
 		for _, port := range host.Ports {
 			for _, script := range port.Scripts {
 				if strings.Contains(script.Output, "password") {
-					return true
+					return true, nil
 				}
 			}
 		}
 	}
-	return false
+	return false, nil
 }


### PR DESCRIPTION
`analyzeResult()`中に発生したエラーを握りつぶさずに呼び出し元に返すように変更しました。
ただし、呼び出し元でそのエラーをそのまま返すとこれまで発生していなかったスキャンエラーが多く検知されてオペレーションの負荷が高くなる可能性があるため、まずは当該エラーを呼び出し元でログ出力だけしておおまかな件数を確認する予定です。
そのため、今回返すようにしたエラーだけを判別するために専用のエラーを追加しています。