### PR TITLE
fix: ddl

### DIFF
--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -486,6 +486,15 @@ CREATE TABLE code_gitleaks_setting (
   PRIMARY KEY(code_github_setting_id)
 ) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
+CREATE TABLE code_gitleaks_cache (
+  code_github_setting_id INT UNSIGNED NOT NULL,
+  repository_full_name VARCHAR(255) NOT NULL,
+  scan_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(code_github_setting_id, repository_full_name)
+) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
 CREATE TABLE code_dependency_setting (
   code_github_setting_id INT UNSIGNED NOT NULL,
   project_id INT UNSIGNED NOT NULL,


### PR DESCRIPTION
code_gitleaks_cacheエンティティを追加します。
gitleaksの差分スキャンがリソースエンティティのupdated_atに依存している課題があるため、このエンティティを追加して左記の依存を解消するのが目的です