### PR TITLE
add base image build

### DIFF
--- a/codebuild/applicationscan-base/buildspec-batch.yml
+++ b/codebuild/applicationscan-base/buildspec-batch.yml
@@ -1,0 +1,38 @@
+batch:
+  build-graph:
+    - identifier: build_amd64
+      buildspec: codebuild/applicationscan-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          OS: linux
+          ARCH: amd64
+          APPLICATIONSCAN_VERSION: v2.10.0
+    - identifier: build_arm64
+      buildspec: codebuild/applicationscan-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          OS: linux
+          ARCH: arm64
+          APPLICATIONSCAN_VERSION: v2.10.0
+    - identifier: build_manifest
+      buildspec: codebuild/applicationscan-base/buildspec-manifest.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          APPLICATIONSCAN_VERSION: v2.10.0
+      depend-on:
+        - build_amd64
+        - build_arm64
+
+

--- a/codebuild/applicationscan-base/buildspec-image.yml
+++ b/codebuild/applicationscan-base/buildspec-image.yml
@@ -1,0 +1,38 @@
+version: 0.2
+
+env:
+  variables:
+    IMAGE_APPLICATIONSCAN_BASE: "diagnosis/applicationscan-base"
+
+phases:
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+      - REGISTORY="public.ecr.aws/risken"
+      - REPO_REGION="us-east-1"
+
+      - echo Logging in to Amazon ECR...
+      - codebuild-breakpoint
+      - aws ecr-public get-login-password --region ${REPO_REGION} | docker login --username AWS --password-stdin ${REGISTORY}
+  build:
+    commands:
+      - echo Build applicationscan base image started on `date`
+      - git clone https://github.com/zaproxy/zaproxy.git
+      - cd zaproxy
+      - git checkout ${APPLICATIONSCAN_VERSION}
+      - TAG=${APPLICATIONSCAN_VERSION}_${OS}_${ARCH}
+      - docker build ${BUILD_OPT} -t ${IMAGE_APPLICATIONSCAN_BASE}:${TAG} -f docker/Dockerfile-bare ./docker
+
+      - echo Tagging the images...
+      # tag the specific version
+      - docker tag ${IMAGE_APPLICATIONSCAN_BASE}:${TAG} ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+
+      # specific version
+      - docker push ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}

--- a/codebuild/applicationscan-base/buildspec-manifest.yml
+++ b/codebuild/applicationscan-base/buildspec-manifest.yml
@@ -1,0 +1,43 @@
+version: 0.2
+
+env:
+  variables:
+    IMAGE_APPLICATIONSCAN_BASE: "diagnosis/applicationscan-base"
+
+phases:
+  install:
+    commands:
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+      - REGISTORY="public.ecr.aws/risken"
+      - REPO_REGION="us-east-1"
+
+      - echo Logging in to Amazon ECR...
+      - aws ecr-public get-login-password --region ${REPO_REGION} | docker login --username AWS --password-stdin ${REGISTORY}
+  build:
+    commands:
+      - echo Build applicationscan base image manifest started on `date`
+      - TAG=${APPLICATIONSCAN_VERSION}
+      # version tag
+      - docker manifest create ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG} ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_amd64 ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG} ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG} ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_arm64
+      # latest
+      - docker manifest create ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:latest ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_amd64 ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:latest ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:latest ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}_linux_arm64
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker manifest...
+      # push manifests
+      - docker manifest push ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}
+      - docker manifest push ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:latest
+      # inspect
+      - docker manifest inspect ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:${TAG}
+      - docker manifest inspect ${REGISTORY}/${IMAGE_APPLICATIONSCAN_BASE}:latest

--- a/codebuild/dependency-base-image/buildspec-batch.yml
+++ b/codebuild/dependency-base-image/buildspec-batch.yml
@@ -1,0 +1,38 @@
+batch:
+  build-graph:
+    - identifier: build_amd64
+      buildspec: codebuild/dependency-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          OS: linux
+          ARCH: amd64
+          DEPENDENCY_BASE_VERSION: v0.0.2
+    - identifier: build_arm64
+      buildspec: codebuild/dependency-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          OS: linux
+          ARCH: arm64
+          DEPENDENCY_BASE_VERSION: v0.0.2
+    - identifier: build_manifest
+      buildspec: codebuild/dependency-base/buildspec-manifest.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          DEPENDENCY_BASE_VERSION: v0.0.2
+      depend-on:
+        - build_amd64
+        - build_arm64
+
+

--- a/codebuild/dependency-base-image/buildspec-image.yml
+++ b/codebuild/dependency-base-image/buildspec-image.yml
@@ -1,0 +1,34 @@
+version: 0.2
+
+env:
+  variables:
+    REGISTRY: "public.ecr.aws/risken"
+    IMAGE_DEPENDENCY_BASE: "code/dependency-base"
+
+phases:
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+
+      - echo Logging in to Amazon ECR...
+      - codebuild-breakpoint
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin  ${REGISTRY}
+  build:
+    commands:
+      - echo Build dependency base image started on `date`
+      - TAG=${DEPENDENCY_BASE_VERSION}_${OS}_${ARCH}
+      - cd dockers/dependency-base
+      - docker build ${BUILD_OPT} -t ${IMAGE_DEPENDENCY_BASE}:${TAG} .
+
+      - echo Tagging the images...
+      # tag the specific version
+      - docker tag ${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+
+      # specific version
+      - docker push ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}

--- a/codebuild/dependency-base-image/buildspec-manifest.yml
+++ b/codebuild/dependency-base-image/buildspec-manifest.yml
@@ -1,0 +1,41 @@
+version: 0.2
+
+env:
+  variables:
+    REGISTRY: "public.ecr.aws/risken"
+    IMAGE_DEPENDENCY_BASE: "code/dependency-base"
+
+phases:
+  install:
+    commands:
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+
+      - echo Logging in to Amazon ECR...
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REGISTRY}
+  build:
+    commands:
+      - echo Build dependency base image manifest started on `date`
+      - TAG=${DEPENDENCY_BASE_VERSION}
+      # version tag
+      - docker manifest create ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      # latest
+      - docker manifest create ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker manifest...
+      # push manifests
+      - docker manifest push ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
+      - docker manifest push ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest
+      # inspect
+      - docker manifest inspect ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
+      - docker manifest inspect ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest

--- a/codebuild/subdomain-base/buildspec-batch.yml
+++ b/codebuild/subdomain-base/buildspec-batch.yml
@@ -1,0 +1,38 @@
+batch:
+  build-graph:
+    - identifier: build_amd64
+      buildspec: codebuild/subdomain-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          OS: linux
+          ARCH: amd64
+          SUBDOMAIN_BASE_VERSION: v0.0.2
+    - identifier: build_arm64
+      buildspec: codebuild/subdomain-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          OS: linux
+          ARCH: arm64
+          SUBDOMAIN_BASE_VERSION: v0.0.2
+    - identifier: build_manifest
+      buildspec: codebuild/subdomain-base/buildspec-manifest.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          SUBDOMAIN_BASE_VERSION: v0.0.2
+      depend-on:
+        - build_amd64
+        - build_arm64
+
+

--- a/codebuild/subdomain-base/buildspec-image.yml
+++ b/codebuild/subdomain-base/buildspec-image.yml
@@ -1,0 +1,42 @@
+version: 0.2
+
+env:
+  variables:
+    REGISTRY: "public.ecr.aws/risken"
+    IMAGE_SUBDOMAIN_BASE: "osint/subdomain-base"
+  parameter-store:
+    GITHUB_USER: "/build/GITHUB_USER"
+    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+
+phases:
+  install:
+    commands:
+      - echo "machine github.com" > ~/.netrc
+      - echo "login ${GITHUB_USER}" >> ~/.netrc
+      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+
+      - echo Logging in to Amazon ECR...
+      - codebuild-breakpoint
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin  ${REGISTRY}
+  build:
+    commands:
+      - echo Build subdomain base image started on `date`
+      - TAG=${SUBDOMAIN_BASE_VERSION}_${OS}_${ARCH}
+      - cd dockers/subdomain-base
+      - docker build ${BUILD_OPT} -t ${IMAGE_SUBDOMAIN_BASE}:${TAG} .
+
+      - echo Tagging the images...
+      # tag the specific version
+      - docker tag ${IMAGE_SUBDOMAIN_BASE}:${TAG} ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+
+      # specific version
+      - docker push ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}

--- a/codebuild/subdomain-base/buildspec-manifest.yml
+++ b/codebuild/subdomain-base/buildspec-manifest.yml
@@ -1,0 +1,47 @@
+version: 0.2
+
+env:
+  variables:
+    REGISTRY: "public.ecr.aws/risken"
+    IMAGE_SUBDOMAIN_BASE: "osint/subdomain-base"
+  parameter-store:
+    GITHUB_USER: "/build/GITHUB_USER"
+    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+
+phases:
+  install:
+    commands:
+      - echo "machine github.com" > ~/.netrc
+      - echo "login ${GITHUB_USER}" >> ~/.netrc
+      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+
+      - echo Logging in to Amazon ECR...
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin  ${REGISTRY}
+  build:
+    commands:
+      - echo Build subdomain base image manifest started on `date`
+      - TAG=${SUBDOMAIN_BASE_VERSION}
+      # version tag
+      - docker manifest create ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG} ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG} ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG} ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_arm64
+      # latest
+      - docker manifest create ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:latest ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:latest ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:latest ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}_linux_arm64
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker manifest...
+      # push manifests
+      - docker manifest push ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}
+      - docker manifest push ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:latest
+      # inspect
+      - docker manifest inspect ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:${TAG}
+      - docker manifest inspect ${REGISTRY}/${IMAGE_SUBDOMAIN_BASE}:latest

--- a/codebuild/website-base/buildspec-batch.yml
+++ b/codebuild/website-base/buildspec-batch.yml
@@ -1,0 +1,38 @@
+batch:
+  build-graph:
+    - identifier: build_amd64
+      buildspec: codebuild/website-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          OS: linux
+          ARCH: amd64
+          WEBSITE_BASE_VERSION: v0.0.2
+    - identifier: build_arm64
+      buildspec: codebuild/website-base/buildspec-image.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          OS: linux
+          ARCH: arm64
+          WEBSITE_BASE_VERSION: v0.0.2
+    - identifier: build_manifest
+      buildspec: codebuild/website-base/buildspec-manifest.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          WEBSITE_BASE_VERSION: v0.0.2
+      depend-on:
+        - build_amd64
+        - build_arm64
+
+

--- a/codebuild/website-base/buildspec-image.yml
+++ b/codebuild/website-base/buildspec-image.yml
@@ -1,0 +1,42 @@
+version: 0.2
+
+env:
+  variables:
+    REGISTRY: "public.ecr.aws/risken"
+    IMAGE_WEBSITE_BASE: "osint/website-base"
+  parameter-store:
+    GITHUB_USER: "/build/GITHUB_USER"
+    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+
+phases:
+  install:
+    commands:
+      - echo "machine github.com" > ~/.netrc
+      - echo "login ${GITHUB_USER}" >> ~/.netrc
+      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+
+      - echo Logging in to Amazon ECR...
+      - codebuild-breakpoint
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin  ${REGISTRY}
+  build:
+    commands:
+      - echo Build subdomain base image started on `date`
+      - TAG=${WEBSITE_BASE_VERSION}_${OS}_${ARCH}
+      - cd dockers/website-base
+      - docker build ${BUILD_OPT} -t ${IMAGE_WEBSITE_BASE}:${TAG} .
+
+      - echo Tagging the images...
+      # tag the specific version
+      - docker tag ${IMAGE_WEBSITE_BASE}:${TAG} ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+
+      # specific version
+      - docker push ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}

--- a/codebuild/website-base/buildspec-manifest.yml
+++ b/codebuild/website-base/buildspec-manifest.yml
@@ -1,0 +1,47 @@
+version: 0.2
+
+env:
+  variables:
+    REGISTRY: "public.ecr.aws/risken"
+    IMAGE_WEBSITE_BASE: "osint/website-base"
+  parameter-store:
+    GITHUB_USER: "/build/GITHUB_USER"
+    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
+
+phases:
+  install:
+    commands:
+      - echo "machine github.com" > ~/.netrc
+      - echo "login ${GITHUB_USER}" >> ~/.netrc
+      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+  pre_build:
+    commands:
+      - echo Setting environment variables
+      - BUILD_OPT="--no-cache --pull"
+
+      - echo Logging in to Amazon ECR...
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin  ${REGISTRY}
+  build:
+    commands:
+      - echo Build website base image manifest started on `date`
+      - TAG=${WEBSITE_BASE_VERSION}
+      # version tag
+      - docker manifest create ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG} ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG} ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG} ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_arm64
+      # latest
+      - docker manifest create ${REGISTRY}/${IMAGE_WEBSITE_BASE}:latest ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_WEBSITE_BASE}:latest ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_WEBSITE_BASE}:latest ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}_linux_arm64
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker manifest...
+      # push manifests
+      - docker manifest push ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}
+      - docker manifest push ${REGISTRY}/${IMAGE_WEBSITE_BASE}:latest
+      # inspect
+      - docker manifest inspect ${REGISTRY}/${IMAGE_WEBSITE_BASE}:${TAG}
+      - docker manifest inspect ${REGISTRY}/${IMAGE_WEBSITE_BASE}:latest

--- a/dockers/dependency-base/Dockerfile
+++ b/dockers/dependency-base/Dockerfile
@@ -1,0 +1,5 @@
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1 as base
+
+FROM aquasec/trivy:0.31.2
+RUN apk add --no-cache ca-certificates tzdata
+COPY --from=base /usr/local/bin/env-injector /usr/local/bin/

--- a/dockers/subdomain-base/Dockerfile
+++ b/dockers/subdomain-base/Dockerfile
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1 as base
+
+FROM ubuntu:20.04
+ARG THE_HARVESSTER_VERSION=4.0.0
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -qy python3 python3-pip libffi-dev libxml2-dev libxslt1-dev git wget  \ 
+  && /usr/bin/python3 -m pip install --upgrade pip && apt clean && apt autoremove -qy
+RUN git clone https://github.com/laramies/theHarvester.git -b ${THE_HARVESSTER_VERSION} \
+  && pip install --no-cache-dir -r /theHarvester/requirements/base.txt \
+  && mkdir /results
+COPY --from=base /usr/local/bin/env-injector /usr/local/bin/

--- a/dockers/website-base/Dockerfile
+++ b/dockers/website-base/Dockerfile
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1 as base
+
+FROM node:14-alpine
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV CHROMIUM_BIN /usr/bin/chromium-browser
+ARG WAPPALYZER_VERSION=v6.9.7
+RUN  apk update && apk add -u --no-cache \
+  git \
+  nodejs \
+  udev \
+  chromium \
+  ttf-freefont \
+  yarn \
+  tini \
+  && cd /opt \
+  && git clone https://github.com/AliasIO/wappalyzer.git -b ${WAPPALYZER_VERSION} \
+  && cd wappalyzer \
+  && yarn install \
+  && yarn run link
+COPY --from=base /usr/local/bin/env-injector /usr/local/bin/


### PR DESCRIPTION
各ネームスペースごとのリポジトリに存在していたbase imageを作成する用のファイルを集約します
また、baseイメージ内でenv-injectorをbuildしていたものに関して、
risken-baseからenv-injectorをコピーするように修正しました