### PR TITLE
fix: recommend type length

### DIFF
--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -184,7 +184,7 @@ CREATE TABLE finding_setting (
 CREATE TABLE recommend (
   recommend_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
   data_source VARCHAR(64) NOT NULL,
-  type VARCHAR(128) NOT NULL,
+  type VARCHAR(255) NOT NULL,
   risk TEXT NULL,
   recommendation TEXT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
レコメンド情報をFindingごとで細かく定義するケースで、ユニーク制約のある「タイプ」項目のキーの長さ現状だと足りなくなってしまったため拡張したいです。