### PR TITLE
Add GitHub App user OAuth client

### DIFF
--- a/pkg/githubappauth/user_oauth.go
+++ b/pkg/githubappauth/user_oauth.go
@@ -1,0 +1,191 @@
+package githubappauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/go-github/v44/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	defaultGitHubOAuthBaseURL = "https://github.com/"
+)
+
+var defaultAllowedOAuthBaseURLHosts = map[string]struct{}{
+	"github.com": {},
+}
+
+var newGitHubOAuthHTTPClient = func(ctx context.Context, token *oauth2.Token) *http.Client {
+	return oauth2.NewClient(ctx, oauth2.StaticTokenSource(token))
+}
+
+// OAuthConfig is the GitHub App user-to-server OAuth credential set.
+type OAuthConfig struct {
+	ClientID                 string
+	ClientSecret             string
+	OAuthBaseURL             string
+	APIBaseURL               string
+	Scopes                   []string
+	AllowedOAuthBaseURLHosts []string
+	AllowedAPIBaseURLHosts   []string
+}
+
+type OAuthClient struct {
+	oauthConfig       *oauth2.Config
+	apiBaseURL        *url.URL
+	allowedAPIHosts   map[string]struct{}
+	allowedOAuthHosts map[string]struct{}
+}
+
+func NewOAuthClient(conf *OAuthConfig) (*OAuthClient, error) {
+	if conf == nil || (conf.ClientID == "" && conf.ClientSecret == "") {
+		return &OAuthClient{}, nil
+	}
+	if conf.ClientID == "" || conf.ClientSecret == "" {
+		return nil, errors.New("github app oauth client id and client secret are required together")
+	}
+	client := &OAuthClient{
+		allowedAPIHosts:   allowedBaseURLHosts(conf.AllowedAPIBaseURLHosts),
+		allowedOAuthHosts: allowedOAuthBaseURLHosts(conf.AllowedOAuthBaseURLHosts),
+	}
+	oauthBaseURL, err := client.validateOAuthBaseURL(conf.OAuthBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	apiBaseURL, err := client.validateAPIBaseURL(conf.APIBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	client.apiBaseURL = apiBaseURL
+	client.oauthConfig = &oauth2.Config{
+		ClientID:     conf.ClientID,
+		ClientSecret: conf.ClientSecret,
+		Scopes:       conf.Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  oauthBaseURL.ResolveReference(&url.URL{Path: "login/oauth/authorize"}).String(),
+			TokenURL: oauthBaseURL.ResolveReference(&url.URL{Path: "login/oauth/access_token"}).String(),
+		},
+	}
+	return client, nil
+}
+
+func (c *OAuthClient) Enabled() bool {
+	return c != nil && c.oauthConfig != nil
+}
+
+func allowedOAuthBaseURLHosts(configuredHosts []string) map[string]struct{} {
+	allowedHosts := make(map[string]struct{}, len(defaultAllowedOAuthBaseURLHosts)+len(configuredHosts))
+	for host := range defaultAllowedOAuthBaseURLHosts {
+		allowedHosts[host] = struct{}{}
+	}
+	for _, host := range configuredHosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized == "" {
+			continue
+		}
+		allowedHosts[normalized] = struct{}{}
+	}
+	return allowedHosts
+}
+
+func (c *OAuthClient) validateOAuthBaseURL(baseURL string) (*url.URL, error) {
+	if baseURL == "" {
+		baseURL = defaultGitHubOAuthBaseURL
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("github app oauth_base_url must use https: %s", baseURL)
+	}
+	if _, ok := c.allowedOAuthHosts[strings.ToLower(u.Hostname())]; !ok {
+		return nil, fmt.Errorf("github app oauth_base_url host is not allowed: %s", u.Hostname())
+	}
+	if u.Path == "" || !strings.HasSuffix(u.Path, "/") {
+		u.Path += "/"
+	}
+	return u, nil
+}
+
+func (c *OAuthClient) validateAPIBaseURL(baseURL string) (*url.URL, error) {
+	if baseURL == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("github app api_base_url must use https: %s", baseURL)
+	}
+	if _, ok := c.allowedAPIHosts[strings.ToLower(u.Hostname())]; !ok {
+		return nil, fmt.Errorf("github app api_base_url host is not allowed: %s", u.Hostname())
+	}
+	if u.Path == "" || !strings.HasSuffix(u.Path, "/") {
+		u.Path += "/"
+	}
+	return u, nil
+}
+
+func (c *OAuthClient) AuthorizationURL(state string) (string, error) {
+	if !c.Enabled() {
+		return "", errors.New("github app oauth is not configured")
+	}
+	if state == "" {
+		return "", errors.New("github app oauth state is required")
+	}
+	return c.oauthConfig.AuthCodeURL(state), nil
+}
+
+func (c *OAuthClient) ExchangeCode(ctx context.Context, code string) (*oauth2.Token, error) {
+	if !c.Enabled() {
+		return nil, errors.New("github app oauth is not configured")
+	}
+	if strings.TrimSpace(code) == "" {
+		return nil, errors.New("github app oauth code is required")
+	}
+	token, err := c.oauthConfig.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("exchange github app oauth code: %w", err)
+	}
+	if token == nil || token.AccessToken == "" {
+		return nil, errors.New("github app oauth access token is empty")
+	}
+	return token, nil
+}
+
+func (c *OAuthClient) NewUserClient(ctx context.Context, token *oauth2.Token) (*github.Client, error) {
+	if !c.Enabled() {
+		return nil, errors.New("github app oauth is not configured")
+	}
+	if token == nil || token.AccessToken == "" {
+		return nil, errors.New("github app oauth access token is required")
+	}
+	httpClient := newGitHubOAuthHTTPClient(ctx, token)
+	client := github.NewClient(httpClient)
+	if c.apiBaseURL != nil {
+		client.BaseURL = c.apiBaseURL
+	}
+	return client, nil
+}
+
+func (c *OAuthClient) GetAuthenticatedUser(ctx context.Context, token *oauth2.Token) (*github.User, error) {
+	client, err := c.NewUserClient(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	user, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("get authenticated github user: %w", err)
+	}
+	if user == nil || user.GetLogin() == "" {
+		return nil, errors.New("authenticated github user login is empty")
+	}
+	return user, nil
+}

--- a/pkg/githubappauth/user_oauth_test.go
+++ b/pkg/githubappauth/user_oauth_test.go
@@ -1,0 +1,193 @@
+package githubappauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestNewOAuthClient(t *testing.T) {
+	cases := []struct {
+		name      string
+		conf      *OAuthConfig
+		wantOAuth bool
+		wantError bool
+	}{
+		{
+			name: "OK no oauth",
+		},
+		{
+			name: "OK empty oauth",
+			conf: &OAuthConfig{},
+		},
+		{
+			name:      "OK oauth",
+			conf:      &OAuthConfig{ClientID: "client-id", ClientSecret: "client-secret"},
+			wantOAuth: true,
+		},
+		{
+			name:      "NG missing client secret",
+			conf:      &OAuthConfig{ClientID: "client-id"},
+			wantError: true,
+		},
+		{
+			name:      "NG untrusted oauth host",
+			conf:      &OAuthConfig{ClientID: "client-id", ClientSecret: "client-secret", OAuthBaseURL: "https://attacker.example"},
+			wantError: true,
+		},
+		{
+			name:      "NG untrusted api host",
+			conf:      &OAuthConfig{ClientID: "client-id", ClientSecret: "client-secret", APIBaseURL: "https://attacker.example"},
+			wantError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client, err := NewOAuthClient(c.conf)
+			if c.wantError {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got := client.Enabled(); got != c.wantOAuth {
+				t.Fatalf("Unexpected GitHub App OAuth support: want=%t, got=%t", c.wantOAuth, got)
+			}
+		})
+	}
+}
+
+func TestAuthorizationURL(t *testing.T) {
+	client, err := NewOAuthClient(&OAuthConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scopes:       []string{"read:org"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	got, err := client.AuthorizationURL("state-value")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse auth url: %v", err)
+	}
+	if u.String() != "https://github.com/login/oauth/authorize?client_id=client-id&response_type=code&scope=read%3Aorg&state=state-value" {
+		t.Fatalf("Unexpected auth url: %s", u.String())
+	}
+}
+
+func TestExchangeCodeAndGetAuthenticatedUser(t *testing.T) {
+	var gotCode string
+	var gotAuthorization string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			if r.Method != http.MethodPost {
+				t.Fatalf("Unexpected token method: %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			gotCode = r.Form.Get("code")
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"access_token":"user-token","token_type":"bearer"}`)); err != nil {
+				t.Fatalf("write token response: %v", err)
+			}
+		case "/user":
+			gotAuthorization = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{"login": "octocat"}); err != nil {
+				t.Fatalf("write user response: %v", err)
+			}
+		default:
+			t.Fatalf("Unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+
+	client, err := NewOAuthClient(&OAuthConfig{
+		ClientID:                 "client-id",
+		ClientSecret:             "client-secret",
+		OAuthBaseURL:             server.URL,
+		APIBaseURL:               server.URL,
+		AllowedOAuthBaseURLHosts: []string{serverURL.Hostname()},
+		AllowedAPIBaseURLHosts:   []string{serverURL.Hostname()},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
+	token, err := client.ExchangeCode(ctx, "oauth-code")
+	if err != nil {
+		t.Fatalf("Unexpected exchange error: %v", err)
+	}
+	if gotCode != "oauth-code" {
+		t.Fatalf("Unexpected oauth code: %s", gotCode)
+	}
+
+	origNewGitHubOAuthHTTPClient := newGitHubOAuthHTTPClient
+	newGitHubOAuthHTTPClient = func(ctx context.Context, token *oauth2.Token) *http.Client {
+		client := server.Client()
+		client.Transport = &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(token),
+			Base:   client.Transport,
+		}
+		return client
+	}
+	defer func() {
+		newGitHubOAuthHTTPClient = origNewGitHubOAuthHTTPClient
+	}()
+
+	user, err := client.GetAuthenticatedUser(context.Background(), token)
+	if err != nil {
+		t.Fatalf("Unexpected user error: %v", err)
+	}
+	if user.GetLogin() != "octocat" {
+		t.Fatalf("Unexpected user login: %s", user.GetLogin())
+	}
+	if !strings.HasPrefix(gotAuthorization, "Bearer ") {
+		t.Fatalf("Unexpected authorization header: %s", gotAuthorization)
+	}
+}
+
+func TestOAuthClientErrors(t *testing.T) {
+	client, err := NewOAuthClient(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if _, err := client.AuthorizationURL("state"); err == nil {
+		t.Fatal("Expected authorization url error but got none")
+	}
+
+	client, err = NewOAuthClient(&OAuthConfig{ClientID: "client-id", ClientSecret: "client-secret"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if _, err := client.AuthorizationURL(""); err == nil {
+		t.Fatal("Expected empty state error but got none")
+	}
+	if _, err := client.ExchangeCode(context.Background(), ""); err == nil {
+		t.Fatal("Expected empty code error but got none")
+	}
+	if _, err := client.GetAuthenticatedUser(context.Background(), nil); err == nil {
+		t.Fatal("Expected empty token error but got none")
+	}
+}


### PR DESCRIPTION
- `common/pkg/githubappauth` に GitHub App の user-to-server OAuth client を追加しました。
- authorization URL生成、OAuth code交換、OAuth tokenによる認証済みGitHubユーザー取得を提供します。
- 既存の server-to-server GitHub App JWT / installation token の挙動は変更していません。
