### PR TITLE
Support GitHub App OAuth redirect URI

### DIFF
--- a/pkg/githubappauth/user_oauth.go
+++ b/pkg/githubappauth/user_oauth.go
@@ -30,6 +30,7 @@ type OAuthConfig struct {
 	ClientSecret             string
 	OAuthBaseURL             string
 	APIBaseURL               string
+	RedirectURL              string
 	Scopes                   []string
 	AllowedOAuthBaseURLHosts []string
 	AllowedAPIBaseURLHosts   []string
@@ -61,10 +62,15 @@ func NewOAuthClient(conf *OAuthConfig) (*OAuthClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	redirectURL, err := validateOAuthRedirectURL(conf.RedirectURL)
+	if err != nil {
+		return nil, err
+	}
 	client.apiBaseURL = apiBaseURL
 	client.oauthConfig = &oauth2.Config{
 		ClientID:     conf.ClientID,
 		ClientSecret: conf.ClientSecret,
+		RedirectURL:  redirectURL,
 		Scopes:       conf.Scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  oauthBaseURL.ResolveReference(&url.URL{Path: "login/oauth/authorize"}).String(),
@@ -111,6 +117,20 @@ func (c *OAuthClient) validateOAuthBaseURL(baseURL string) (*url.URL, error) {
 		u.Path += "/"
 	}
 	return u, nil
+}
+
+func validateOAuthRedirectURL(redirectURL string) (string, error) {
+	if redirectURL == "" {
+		return "", nil
+	}
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		return "", err
+	}
+	if (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		return "", fmt.Errorf("github app oauth redirect_url must be an absolute http or https URL: %s", redirectURL)
+	}
+	return redirectURL, nil
 }
 
 func (c *OAuthClient) validateAPIBaseURL(baseURL string) (*url.URL, error) {

--- a/pkg/githubappauth/user_oauth_test.go
+++ b/pkg/githubappauth/user_oauth_test.go
@@ -46,6 +46,11 @@ func TestNewOAuthClient(t *testing.T) {
 			conf:      &OAuthConfig{ClientID: "client-id", ClientSecret: "client-secret", APIBaseURL: "https://attacker.example"},
 			wantError: true,
 		},
+		{
+			name:      "NG relative redirect url",
+			conf:      &OAuthConfig{ClientID: "client-id", ClientSecret: "client-secret", RedirectURL: "/api/v1/code/github-app/oauth/callback"},
+			wantError: true,
+		},
 	}
 
 	for _, c := range cases {
@@ -71,6 +76,7 @@ func TestAuthorizationURL(t *testing.T) {
 	client, err := NewOAuthClient(&OAuthConfig{
 		ClientID:     "client-id",
 		ClientSecret: "client-secret",
+		RedirectURL:  "https://risken.example/api/v1/code/github-app/oauth/callback",
 		Scopes:       []string{"read:org"},
 	})
 	if err != nil {
@@ -85,13 +91,14 @@ func TestAuthorizationURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse auth url: %v", err)
 	}
-	if u.String() != "https://github.com/login/oauth/authorize?client_id=client-id&response_type=code&scope=read%3Aorg&state=state-value" {
+	if u.String() != "https://github.com/login/oauth/authorize?client_id=client-id&redirect_uri=https%3A%2F%2Frisken.example%2Fapi%2Fv1%2Fcode%2Fgithub-app%2Foauth%2Fcallback&response_type=code&scope=read%3Aorg&state=state-value" {
 		t.Fatalf("Unexpected auth url: %s", u.String())
 	}
 }
 
 func TestExchangeCodeAndGetAuthenticatedUser(t *testing.T) {
 	var gotCode string
+	var gotRedirectURL string
 	var gotAuthorization string
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -103,6 +110,7 @@ func TestExchangeCodeAndGetAuthenticatedUser(t *testing.T) {
 				t.Fatalf("parse form: %v", err)
 			}
 			gotCode = r.Form.Get("code")
+			gotRedirectURL = r.Form.Get("redirect_uri")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`{"access_token":"user-token","token_type":"bearer"}`)); err != nil {
 				t.Fatalf("write token response: %v", err)
@@ -128,6 +136,7 @@ func TestExchangeCodeAndGetAuthenticatedUser(t *testing.T) {
 		ClientSecret:             "client-secret",
 		OAuthBaseURL:             server.URL,
 		APIBaseURL:               server.URL,
+		RedirectURL:              "https://risken.example/api/v1/code/github-app/oauth/callback",
 		AllowedOAuthBaseURLHosts: []string{serverURL.Hostname()},
 		AllowedAPIBaseURLHosts:   []string{serverURL.Hostname()},
 	})
@@ -141,6 +150,9 @@ func TestExchangeCodeAndGetAuthenticatedUser(t *testing.T) {
 	}
 	if gotCode != "oauth-code" {
 		t.Fatalf("Unexpected oauth code: %s", gotCode)
+	}
+	if gotRedirectURL != "https://risken.example/api/v1/code/github-app/oauth/callback" {
+		t.Fatalf("Unexpected redirect_uri: %s", gotRedirectURL)
 	}
 
 	origNewGitHubOAuthHTTPClient := newGitHubOAuthHTTPClient


### PR DESCRIPTION
## PRの概要

GitHub App の User-to-Server OAuth では、認可リクエストと token exchange の両方で同じ `redirect_uri` を明示することで、GitHub App 側に複数 Callback URL が設定されている場合でも意図した callback 先に固定できます。この PR では `githubappauth.OAuthConfig` に `RedirectURL` を追加し、認可URL生成と code 交換の双方で同一の redirect URI を扱えるようにしました。未設定時は従来どおり `redirect_uri` を省略するため、既存利用側の互換性は維持しています。

| 条件 | 変更前 | 変更後 |
|---|---|---|
| `RedirectURL` 未設定 | `redirect_uri` を送らない | 従来どおり `redirect_uri` を送らない |
| `RedirectURL` 設定済み | 認可URLにもtoken exchangeにも `redirect_uri` を指定できない | 認可URLとtoken exchangeの両方に同じ `redirect_uri` を指定する |
| 相対URLなど不正な `RedirectURL` | 設定項目がない | OAuth client生成時にエラーにする |

## レビュー観点例

- [ ] `RedirectURL` 未設定時に既存挙動を維持している点
- [ ] 認可URL生成とtoken exchangeで同じ `redirect_uri` を扱うことでOAuthフローの整合性を高めている点
- [ ] `redirect_uri` のバリデーションを絶対HTTP/HTTPS URLに留め、ローカル検証用のHTTP localhostを許容している点
