### PR TITLE
feat: add remediation proposal ddl

### DIFF
--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -237,7 +237,7 @@ CREATE TABLE remediation_proposal (
   request_id VARCHAR(64) NOT NULL,
   finding_id BIGINT UNSIGNED NOT NULL,
   project_id INT UNSIGNED NOT NULL,
-  status VARCHAR(20) NOT NULL,
+  status ENUM('PENDING', 'SUCCEEDED', 'FAILED') NOT NULL DEFAULT 'PENDING',
   error_message TEXT NULL,
   remediation_plan JSON NULL,
   generated_at DATETIME NULL,

--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -234,7 +234,7 @@ CREATE TABLE finding (
 ) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin AUTO_INCREMENT = 1001;
 
 CREATE TABLE remediation_proposal (
-  request_id VARCHAR(64) NOT NULL,
+  remediation_proposal_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
   finding_id BIGINT UNSIGNED NOT NULL,
   project_id INT UNSIGNED NOT NULL,
   status ENUM('PENDING', 'SUCCEEDED', 'FAILED') NOT NULL DEFAULT 'PENDING',
@@ -243,10 +243,10 @@ CREATE TABLE remediation_proposal (
   generated_at DATETIME NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY(request_id),
+  PRIMARY KEY(remediation_proposal_id),
   INDEX idx_finding(finding_id, project_id, created_at DESC),
   INDEX idx_project_status(project_id, status, created_at)
-) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin AUTO_INCREMENT = 1001;
 
 CREATE TABLE finding_tag (
   finding_tag_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -233,6 +233,21 @@ CREATE TABLE finding (
   INDEX idx_score(project_id, score, updated_at)
 ) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin AUTO_INCREMENT = 1001;
 
+CREATE TABLE remediation_proposal (
+  request_id VARCHAR(64) NOT NULL,
+  finding_id BIGINT UNSIGNED NOT NULL,
+  project_id INT UNSIGNED NOT NULL,
+  status VARCHAR(20) NOT NULL,
+  error_message TEXT NULL,
+  remediation_plan JSON NULL,
+  generated_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(request_id),
+  INDEX idx_finding(finding_id, project_id, created_at DESC),
+  INDEX idx_project_status(project_id, status, created_at)
+) ENGINE = InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
 CREATE TABLE finding_tag (
   finding_tag_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   finding_id BIGINT UNSIGNED NOT NULL,

--- a/middleware/db/01_ddl_mimosa.sql
+++ b/middleware/db/01_ddl_mimosa.sql
@@ -238,7 +238,7 @@ CREATE TABLE remediation_proposal (
   finding_id BIGINT UNSIGNED NOT NULL,
   project_id INT UNSIGNED NOT NULL,
   status ENUM('PENDING', 'SUCCEEDED', 'FAILED') NOT NULL DEFAULT 'PENDING',
-  error_message TEXT NULL,
+  status_detail TEXT NULL,
   remediation_plan JSON NULL,
   generated_at DATETIME NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## PRの概要

AI修復提案機能で生成リクエスト単位の修復提案を保存するため、`remediation_proposal` テーブルをDDLに追加します。`request_id` をキーに、対象Finding、Project、生成状態、状態詳細、修復提案JSON、生成日時を保持できるようにします。

## 背景

AI修復提案機能のため、まず修復提案を保存するDDLを定義する必要があります。

## 修正点

| 変更点 | 内容 |
|---|---|
| テーブル追加 | `remediation_proposal` テーブルを追加 |
| 状態管理 | `status` を `PENDING` / `SUCCEEDED` / `FAILED` のENUMで定義 |
| 補足情報 | `status_detail` を `TEXT NULL` で定義 |
| 提案内容 | `remediation_plan` を `JSON NULL` で定義 |
| 参照用index | `finding_id, project_id, created_at` と `project_id, status, created_at` のindexを追加 |

## 重点レビューポイント

-  status ENUM('PENDING', 'SUCCEEDED', 'FAILED') NOT NULL DEFAULT 'PENDING'でENUMにする設計が妥当かどうか
- `status_detail` の型と名前が既存のRISKENのDDL命名に合っているか
