### PR TITLE
feat: add ai remediation proposal queue

### DIFF
--- a/middleware/queue/elasticmq.conf
+++ b/middleware/queue/elasticmq.conf
@@ -51,8 +51,8 @@ queues {
         delay = 5 seconds
         receiveMessageWait = 0 seconds
     }
-    aws-ai-remediation-proposal {
-        defaultVisibilityTimeout = 300 seconds
+    aws-remediation-proposal {
+        defaultVisibilityTimeout = 200 seconds
         delay = 5 seconds
         receiveMessageWait = 0 seconds
     }

--- a/middleware/queue/elasticmq.conf
+++ b/middleware/queue/elasticmq.conf
@@ -51,6 +51,11 @@ queues {
         delay = 5 seconds
         receiveMessageWait = 0 seconds
     }
+    aws-ai-remediation-proposal {
+        defaultVisibilityTimeout = 300 seconds
+        delay = 5 seconds
+        receiveMessageWait = 0 seconds
+    }
     osint-subdomain {
         defaultVisibilityTimeout = 900 seconds
         delay = 5 seconds


### PR DESCRIPTION
## PRの概要

修復提案を保存するための `remediation_proposal` テーブルを追加し、ローカル SQS 環境向けに `aws-remediation-proposal` queue を追加します。テーブルは提案生成の状態、失敗時の詳細、生成された修復提案、生成日時を保存できる構成にしています。

## 背景

ローカル SQS 環境でも修復提案 Worker の起動確認ができるように queue 定義が必要なため。

## 修正点

| 変更点 | 内容 |
|---|---|
| DDL | `remediation_proposal` テーブルを追加 |
| 主キー | `remediation_proposal_id` を `INT UNSIGNED AUTO_INCREMENT` の主キーとして追加 |
| 状態管理 | `status` を `PENDING` / `SUCCEEDED` / `FAILED` の ENUM として追加 |
| 生成結果 | `status_detail` / `remediation_plan` / `generated_at` を追加 |
| Index | finding 単位の参照用 index と project/status 単位の参照用 index を追加 |
| ローカル SQS | ElasticMQ に `aws-remediation-proposal` queue を追加し、`defaultVisibilityTimeout` を `200 seconds` に設定 |

## 重点レビューポイント

- `aws-remediation-proposal` のように `ai-` prefix を付けない queue 名でよいか
- `defaultVisibilityTimeout = 200 seconds` が修復提案 Worker のローカル起動確認用途として妥当か

## 関連PR

- [core#472](https://github.com/ca-risken/core/pull/472): `remediation_proposal` の model / repository 追加
- [core#473](https://github.com/ca-risken/core/pull/473): 修復提案を保存・更新する Core AI Service API 追加
- [datasource-api#124](https://github.com/ca-risken/datasource-api/pull/124): 修復提案生成リクエストを受け、SQS に送信する処理の追加

## 動作確認

- ElasticMQ 設定の差分確認
- `make build`が成功すること
